### PR TITLE
2022.5 fix public questionnaire not registered

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Version 1.2.3
+Correction SQL tables (pour la v14)
 
 
 ## Version 1.2

--- a/core/modules/modquestionnaire.class.php
+++ b/core/modules/modquestionnaire.class.php
@@ -61,7 +61,7 @@ class modquestionnaire extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module questionnaire";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.2.2';
+		$this->version = '1.2.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/public/toAnswer.php
+++ b/public/toAnswer.php
@@ -148,17 +148,26 @@ if ($action == 'save_answer')
 						}
 						else
 							$answer->fk_choix = $answer_user;
+							$answer->fk_choix_col = 'DEFAULT';
 
-						$answer->save();
+						$result = $answer->save();
+						if ($result == -1) {
+							setEventMessage($answer->errors, 'errors');
+						}
 					}
 				} elseif (!is_array($content) && !empty($content))
 				{
 					$answer = new Answer($db);
 					$answer->fk_invitation_user = $fk_invitation;
 					$answer->fk_question = $fk_question;
+					$answer->fk_choix = 'DEFAULT';
+					$answer->fk_choix_col = 'DEFAULT';
 					$answer->value = $content;
 
-					$answer->save();
+					$result = $answer->save();
+					if ($result == -1) {
+						setEventMessage($answer->errors, 'errors');
+					}
 				}
 			}
 		}

--- a/sql/update_1.2.3.sql
+++ b/sql/update_1.2.3.sql
@@ -1,0 +1,8 @@
+ALTER TABLE llx_quest_questionnaire MODIFY COLUMN import_key INT(11) NULL;
+ALTER TABLE llx_quest_questionnaire MODIFY COLUMN originid INT(11) NULL;
+ALTER TABLE llx_quest_questionnaire MODIFY COLUMN answer_deadline INT(11) NULL;
+
+ALTER TABLE llx_quest_invitation_user MODIFY COLUMN fk_usergroup INT(11) NULL;
+ALTER TABLE llx_quest_invitation_user MODIFY COLUMN sent INT(11) NULL;
+
+ALTER TABLE llx_quest_question MODIFY COLUMN originid INT(11) NULL;


### PR DESCRIPTION
fix: questionnaire answers would not be registered.

This due to the CommonObject::createCommon() method, at line 8391:
`$values[$k] = $this->quote($v, $value); // May return string 'NULL' if $value is null`

If fk_choix and fk_choix_col are not defined, they are set to NULL, which is forbidden.
This commit set them to the default value, which is 0.
